### PR TITLE
refactor: rebrand Owlstack to Fopost and namespace under Fopost\Social

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,6 +1,6 @@
-You are working on owlstack-laravel, a Laravel integration package for the Owlstack social media publishing platform.
+You are working on fopost-social-laravel, a Laravel integration package for the Fopost social media publishing platform.
 
-This is a thin wrapper around owlstack/owlstack-core. All platform logic, formatting, and HTTP transport live in the core package. Do not duplicate core behavior.
+This is a thin wrapper around fopost/social-core. All platform logic, formatting, and HTTP transport live in the core package. Do not duplicate core behavior.
 
 Key conventions:
 - PHP 8.1+ with declare(strict_types=1) in every file
@@ -10,11 +10,11 @@ Key conventions:
 - One class per file
 
 Architecture:
-- OwlstackServiceProvider registers core services into the Laravel container
+- FopostSocialServiceProvider registers core services into the Laravel container
 - SendTo is the high-level publishing API (telegram(), twitter(), facebook(), etc.)
-- Owlstack facade proxies to SendTo
+- Fopost facade proxies to SendTo
 - LaravelEventDispatcher bridges core events to Laravel's event system
-- Config in config/owlstack.php, populated from .env
+- Config in config/fopost-social.php, populated from .env
 - Supports Laravel 10.x, 11.x, 12.x
 
 Testing:
@@ -24,7 +24,7 @@ Testing:
 - Unit tests in tests/Unit/, feature tests in tests/Feature/
 
 Do not:
-- Duplicate platform logic from owlstack-core
+- Duplicate platform logic from fopost-social-core
 - Hardcode API URLs or credentials
 - Commit real API tokens
 - Use dd(), var_dump, or print_r in production code

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,10 +1,10 @@
-You are working on **owlstack-laravel**, a Laravel integration package for the Owlstack social media publishing platform.
+You are working on **fopost-social-laravel**, a Laravel integration package for the Fopost social media publishing platform.
 
 ## Key Facts
 
-- This is a **thin wrapper** around `owlstack/owlstack-core`. All platform logic, formatting, and HTTP transport live in the core package.
+- This is a **thin wrapper** around `fopost/social-core`. All platform logic, formatting, and HTTP transport live in the core package.
 - Supports Laravel 10.x, 11.x, and 12.x with PHP 8.1+.
-- Namespace: `Owlstack\Laravel\`
+- Namespace: `Fopost\Social\Laravel\`
 - Uses Orchestra Testbench for testing.
 
 ## Code Conventions
@@ -17,19 +17,19 @@ You are working on **owlstack-laravel**, a Laravel integration package for the O
 
 ## Architecture
 
-- `OwlstackServiceProvider` registers all core services into the Laravel container.
+- `FopostSocialServiceProvider` registers all core services into the Laravel container.
 - `SendTo` is the high-level API — methods like `telegram()`, `twitter()`, `facebook()`.
-- `Owlstack` facade proxies to `SendTo`.
+- `Fopost` facade proxies to `SendTo`.
 - `LaravelEventDispatcher` bridges core events to Laravel's event system.
-- Config lives in `config/owlstack.php`, populated from `.env`.
+- Config lives in `config/fopost-social.php`, populated from `.env`.
 
 ## Rules
 
-- Never duplicate platform logic from owlstack-core.
+- Never duplicate platform logic from fopost-social-core.
 - Never hardcode API URLs or credentials.
 - Never commit real API tokens.
 - Never use `dd()`, `var_dump`, or `print_r` in production code.
-- Platform-specific changes belong in owlstack-core, not here.
+- Platform-specific changes belong in fopost-social-core, not here.
 - Laravel-specific features (artisan, queues, middleware) belong here.
 
 ## Testing

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,7 @@
             ]
         },
         {
-            "name": "Debug Owlstack Package",
+            "name": "Debug Fopost Package",
             "type": "php",
             "request": "launch",
             "program": "${workspaceFolder}/examples/laravel-12/artisan",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for AI coding agents (OpenAI Codex, GitHub Copilot Workspace, GPT-b
 
 ## Identity
 
-This is **owlstack-laravel**, a Laravel integration package for [Owlstack Core](https://github.com/owlstacks/owlstack-core). It provides a thin, idiomatic Laravel wrapper around the framework-agnostic core library for publishing content to social media platforms.
+This is **fopost-social-laravel**, a Laravel integration package for [Fopost Core](https://github.com/fopost/social-core). It provides a thin, idiomatic Laravel wrapper around the framework-agnostic core library for publishing content to social media platforms.
 
 ## Setup
 
@@ -31,17 +31,17 @@ All tests must pass before submitting changes.
 
 - PHP 8.1+ with `declare(strict_types=1);` in every file.
 - Follow PSR-12 coding standard.
-- PSR-4 autoloading: `Owlstack\Laravel\` maps to `src/`.
+- PSR-4 autoloading: `Fopost\Social\Laravel\` maps to `src/`.
 - Fully type all parameters and return types.
 - Use readonly constructor promotion for value objects.
 - Use named arguments for clarity when constructing objects.
 
 ## Architecture Rules
 
-1. **Thin wrapper only.** This package delegates all platform logic, formatting, and HTTP transport to `owlstack/owlstack-core`. Do not duplicate or override core behavior.
+1. **Thin wrapper only.** This package delegates all platform logic, formatting, and HTTP transport to `fopost/social-core`. Do not duplicate or override core behavior.
 2. **Laravel conventions.** Use service providers, facades, config files, and event dispatching in the standard Laravel way.
 3. **Auto-discovery.** The service provider and facade alias are registered via `composer.json` `extra.laravel` — no manual registration needed.
-4. **Config-driven.** All credentials and settings come from `config/owlstack.php`, populated from `.env` variables. Never hardcode credentials.
+4. **Config-driven.** All credentials and settings come from `config/fopost-social.php`, populated from `.env` variables. Never hardcode credentials.
 5. **Event bridging.** Core events (`PostPublished`, `PostFailed`) are dispatched through Laravel's event system via `LaravelEventDispatcher`.
 6. **One class per file.** Each class, interface, and trait lives in its own file.
 
@@ -49,11 +49,11 @@ All tests must pass before submitting changes.
 
 | Path | Purpose |
 |---|---|
-| `src/OwlstackServiceProvider.php` | Service provider — registers core services into the Laravel container |
+| `src/FopostSocialServiceProvider.php` | Service provider — registers core services into the Laravel container |
 | `src/SendTo.php` | High-level API for publishing to platforms |
-| `src/Facades/Owlstack.php` | Laravel facade for `SendTo` |
+| `src/Facades/Fopost.php` | Laravel facade for `SendTo` |
 | `src/Events/LaravelEventDispatcher.php` | Bridges core's `EventDispatcherInterface` to Laravel's event system |
-| `config/owlstack.php` | Publishable configuration file |
+| `config/fopost-social.php` | Publishable configuration file |
 | `tests/Unit/` | Unit tests (SendTo, ServiceProvider) |
 | `tests/Feature/` | Feature/integration tests (Publishing) |
 | `tests/fixtures/` | Test fixture files |
@@ -63,17 +63,17 @@ All tests must pass before submitting changes.
 
 | Class | Role |
 |---|---|
-| `OwlstackServiceProvider` | Registers `OwlstackConfig`, `HttpClient`, platform instances, `PlatformRegistry`, `Publisher`, and `SendTo` as singletons |
+| `FopostSocialServiceProvider` | Registers `FopostConfig`, `HttpClient`, platform instances, `PlatformRegistry`, `Publisher`, and `SendTo` as singletons |
 | `SendTo` | Provides methods like `telegram()`, `twitter()`, `facebook()`, etc. for quick publishing |
-| `Owlstack` (Facade) | Static proxy to `SendTo` — resolves the `'owlstack'` binding |
+| `FopostSocial` (Facade) | Static proxy to `SendTo` — resolves the `'fopost-social'` binding |
 | `LaravelEventDispatcher` | Implements core's `EventDispatcherInterface` using Laravel's `Dispatcher` |
 
 ## Adding a New Feature
 
-1. If the feature is platform-specific (new platform, new API method), it belongs in **owlstack-core**, not here.
+1. If the feature is platform-specific (new platform, new API method), it belongs in **fopost-social-core**, not here.
 2. If the feature is Laravel-specific (artisan commands, middleware, queue jobs), add it here.
 3. Always write tests — unit tests in `tests/Unit/`, feature tests in `tests/Feature/`.
-4. Update `config/owlstack.php` if new configuration keys are needed.
+4. Update `config/fopost-social.php` if new configuration keys are needed.
 
 ## Commit Guidelines
 
@@ -83,7 +83,7 @@ All tests must pass before submitting changes.
 
 ## Do Not
 
-- Duplicate platform logic that belongs in `owlstack-core`.
+- Duplicate platform logic that belongs in `fopost-social-core`.
 - Use static methods or global state outside facades.
 - Hardcode API URLs or credentials.
 - Commit real API tokens, secrets, or credentials.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2026-02-15
 
-Complete rewrite on top of `owlstack/owlstack-core` v1.0. This is a **breaking release** — see the migration guide in the README.
+Complete rewrite on top of `fopost/social-core` v1.0. This is a **breaking release** — see the migration guide in the README.
 
 ### Added
-- Full integration with `owlstack/owlstack-core` ^1.0 as the publishing engine
+- Full integration with `fopost/social-core` ^1.0 as the publishing engine
 - Support for 11 platforms: Telegram, X (Twitter), Facebook, LinkedIn, Instagram, Discord, Slack, Reddit, Pinterest, WhatsApp, and Tumblr
 - `SendTo` class with dedicated convenience methods per platform (`telegram()`, `twitter()`, `facebook()`, `linkedin()`, `reddit()`, `discord()`, `slack()`, `instagram()`, `pinterest()`, `whatsapp()`, `tumblr()`)
-- `Owlstack` Facade with full docblock coverage for IDE autocompletion
+- `Fopost` Facade with full docblock coverage for IDE autocompletion
 - `LaravelEventDispatcher` to bridge core events (`PostPublished`, `PostFailed`) into Laravel's event system
 - Support for Laravel 10, 11, and 12
 - Proxy support with authentication for restricted networks
@@ -23,17 +23,17 @@ Complete rewrite on top of `owlstack/owlstack-core` v1.0. This is a **breaking r
 - `publish()` and `toAll()` methods for advanced use with `Post` objects
 - Comprehensive PHPUnit test suite (Unit + Feature)
 - GitHub Actions CI with PHP 8.1–8.4 and Laravel 10–12 matrix
-- Published config file via `vendor:publish --tag=owlstack-config`
+- Published config file via `vendor:publish --tag=fopost-config`
 - Example Laravel 12 project with controller and routes
 - AI agent guidance files (AGENTS.md, CLAUDE.md, .cursorrules, copilot-instructions.md)
 - README with centered logo, flat-square badges, and Laravel branding
 
 ### Changed
-- Namespace changed from `Alihesari\Larasap` to `Owlstack\Laravel`
+- Namespace changed from `Alihesari\Larasap` to `Fopost\Laravel`
 - All methods now return `PublishResult` value objects instead of raw arrays
 - Facebook Graph API updated to v21.0
 - Replaced static `SendTo::platform()` calls with instance methods (DI or Facade)
-- Migrated from local path repository to Packagist dependency (`owlstack/owlstack-core` ^1.0)
+- Migrated from local path repository to Packagist dependency (`fopost/social-core` ^1.0)
 - Set `minimum-stability` to `stable`
 - Contact email updated to ali@alihesari.com
 
@@ -49,8 +49,8 @@ Complete rewrite on top of `owlstack/owlstack-core` v1.0. This is a **breaking r
 - Rewrote `SendTo` as instance-based API (no more static calls)
 - Added `LaravelEventDispatcher` for core event bridging
 - Added 8 additional platform convenience methods (LinkedIn, Reddit, Discord, Slack, Instagram, Pinterest, WhatsApp, Tumblr)
-- Renamed internal namespace from Synglify to Owlstack
-- Migrated to Packagist with stable dependency on `owlstack/owlstack-core` ^1.0
+- Renamed internal namespace from Synglify to Fopost
+- Migrated to Packagist with stable dependency on `fopost/social-core` ^1.0
 - Replaced Travis CI with GitHub Actions (PHP 8.1–8.4 × Laravel 10–12 matrix)
 - Added comprehensive unit and feature tests
 - Updated README with logo, badges, and full platform documentation
@@ -66,6 +66,6 @@ Complete rewrite on top of `owlstack/owlstack-core` v1.0. This is a **breaking r
 - Simple text and media posting
 - Basic configuration options
 
-[2.0.0]: https://github.com/alihesari/owlstack-laravel/compare/v2.0.0-beta...v2.0.0
-[2.0.0-beta]: https://github.com/alihesari/owlstack-laravel/compare/v1.0.0...v2.0.0-beta
-[1.0.0]: https://github.com/alihesari/owlstack-laravel/releases/tag/v1.0.0 
+[2.0.0]: https://github.com/alihesari/fopost-social-laravel/compare/v2.0.0-beta...v2.0.0
+[2.0.0-beta]: https://github.com/alihesari/fopost-social-laravel/compare/v1.0.0...v2.0.0-beta
+[1.0.0]: https://github.com/alihesari/fopost-social-laravel/releases/tag/v1.0.0 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,28 +1,28 @@
 # CLAUDE.md
 
-This file provides guidance for Claude, Cursor, and other AI assistants working with the Owlstack Laravel codebase.
+This file provides guidance for Claude, Cursor, and other AI assistants working with the Fopost Laravel codebase.
 
 ## Project Overview
 
-**Owlstack Laravel** is the official Laravel integration for the Owlstack social media publishing platform. It wraps [Owlstack Core](https://github.com/owlstacks/owlstack-core) with Laravel-idiomatic services: a service provider, facade, config file, and event bridging.
+**Fopost Laravel** is the official Laravel integration for the Fopost social media publishing platform. It wraps [Fopost Core](https://github.com/fopost/social-core) with Laravel-idiomatic services: a service provider, facade, config file, and event bridging.
 
-- **Repository:** `owlstack/owlstack-laravel`
+- **Repository:** `fopost/social-laravel`
 - **Language:** PHP 8.1+
 - **Framework:** Laravel 10.x, 11.x, 12.x
-- **Core dependency:** `owlstack/owlstack-core` ^1.0
-- **Namespace:** `Owlstack\Laravel\`
+- **Core dependency:** `fopost/social-core` ^1.0
+- **Namespace:** `Fopost\Social\Laravel\`
 - **License:** MIT
 
-## Relationship to Owlstack Core
+## Relationship to Fopost Core
 
-This package is a **thin wrapper**. All platform logic, formatting, HTTP transport, and content models live in `owlstack-core`. This package provides:
+This package is a **thin wrapper**. All platform logic, formatting, HTTP transport, and content models live in `fopost-social-core`. This package provides:
 
 1. **Service Provider** — Wires core classes into Laravel's container
-2. **Facade** — Static access via `Owlstack::telegram(...)`
-3. **Configuration** — `config/owlstack.php` populated from `.env`
+2. **Facade** — Static access via `FopostSocial::telegram(...)`
+3. **Configuration** — `config/fopost-social.php` populated from `.env`
 4. **Event Bridge** — Routes core events through Laravel's event dispatcher
 
-**Rule:** If a change involves platform behavior, API communication, or content formatting, it belongs in `owlstack-core`. If it involves Laravel integration (DI, config, artisan, queues), it belongs here.
+**Rule:** If a change involves platform behavior, API communication, or content formatting, it belongs in `fopost-social-core`. If it involves Laravel integration (DI, config, artisan, queues), it belongs here.
 
 ## Directory Structure
 
@@ -31,12 +31,12 @@ src/
 ├── Events/
 │   └── LaravelEventDispatcher.php  # Bridges core events → Laravel events
 ├── Facades/
-│   └── Owlstack.php                # Facade for SendTo
-├── OwlstackServiceProvider.php     # Registers all services
+│   └── Fopost.php                # Facade for SendTo
+├── FopostSocialServiceProvider.php     # Registers all services
 └── SendTo.php                      # High-level publishing API
 
 config/
-└── owlstack.php                    # Publishable config (credentials, platforms)
+└── fopost.php                    # Publishable config (credentials, platforms)
 
 tests/
 ├── TestCase.php                    # Base test case (extends Orchestra Testbench)
@@ -66,11 +66,11 @@ examples/
 
 ## Service Container Bindings
 
-The `OwlstackServiceProvider` registers these bindings:
+The `FopostSocialServiceProvider` registers these bindings:
 
 | Binding | Resolves To | Lifetime |
 |---|---|---|
-| `OwlstackConfig` | Config built from `config/owlstack.php` | Singleton |
+| `FopostConfig` | Config built from `config/fopost-social.php` | Singleton |
 | `HttpClientInterface` | Core's cURL `HttpClient` (with optional proxy) | Singleton |
 | `HashtagExtractor` | Core's hashtag extraction utility | Singleton |
 | `CharacterTruncator` | Core's text truncation utility | Singleton |
@@ -79,7 +79,7 @@ The `OwlstackServiceProvider` registers these bindings:
 | `PlatformRegistry` | Registry of all active platforms | Singleton |
 | `EventDispatcherInterface` | `LaravelEventDispatcher` | Singleton |
 | `Publisher` | Core's `Publisher` with event dispatcher | Singleton |
-| `'owlstack'` / `SendTo` | `SendTo` instance | Singleton |
+| `'fopost-social'` / `SendTo` | `SendTo` instance | Singleton |
 
 ## Key Patterns
 
@@ -109,7 +109,7 @@ Event::listen(PostPublished::class, fn($e) => ...);
 ### Configuration Flow
 
 ```
-.env variables → config/owlstack.php → OwlstackConfig → Platform constructors
+.env variables → config/fopost-social.php → FopostConfig → Platform constructors
 ```
 
 Only platforms with valid credentials are instantiated and registered.
@@ -146,13 +146,13 @@ composer test
 ### Adding an Artisan Command
 
 1. Create the command class in `src/Console/`.
-2. Register it in `OwlstackServiceProvider::boot()` using `$this->commands([...])`.
+2. Register it in `FopostSocialServiceProvider::boot()` using `$this->commands([...])`.
 3. Add tests in `tests/Feature/`.
 
 ### Adding a New Config Key
 
-1. Add the key to `config/owlstack.php` with a sensible default.
-2. Read it in `OwlstackServiceProvider` when building the relevant service.
+1. Add the key to `config/fopost-social.php` with a sensible default.
+2. Read it in `FopostSocialServiceProvider` when building the relevant service.
 3. Document it in `README.md`.
 
 ### Adding Queue Support
@@ -163,7 +163,7 @@ composer test
 
 ## Things to Avoid
 
-- **Never** duplicate platform logic from `owlstack-core` — always delegate.
+- **Never** duplicate platform logic from `fopost-social-core` — always delegate.
 - **Never** hardcode API URLs or credentials.
 - **Never** commit real API tokens or `.env` files.
 - **Never** suppress errors with the `@` operator.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,8 @@ Before you start, read the **README.md** file for info on the project and how to
 
 Before you post any issue or pull request, search [the issues][issues] and [the pull requests][pulls] to see if it has already been addressed. 
 
-[issues]: https://github.com/alihesari/owlstack-laravel/issues
-[pulls]: https://github.com/alihesari/owlstack-laravel/pulls
+[issues]: https://github.com/alihesari/fopost-social-laravel/issues
+[pulls]: https://github.com/alihesari/fopost-social-laravel/pulls
 
 Here are some best practices that will help us accept/address pull requests and issues:
 
@@ -21,7 +21,7 @@ Here are some best practices that will help us accept/address pull requests and 
 
 Fork, then clone the repo:
 
-    git clone git@github.com:your-username/owlstack-laravel.git
+    git clone git@github.com:your-username/fopost-social-laravel.git
 
 Install dependencies and run the tests:
 
@@ -30,6 +30,6 @@ Install dependencies and run the tests:
 
 Make your changes and push to your fork and [submit a pull request][pr].
 
-[pr]: https://github.com/alihesari/owlstack-laravel/compare
+[pr]: https://github.com/alihesari/fopost-social-laravel/compare
 
 At this point you're waiting on us. We may suggest some changes or improvements or alternatives.

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -20,8 +20,8 @@ A clear and concise description of the issue or feature request.
 
 - PHP version:
 - Laravel version:
-- Owlstack Laravel version:
-- Owlstack Core version:
+- Fopost Laravel version:
+- Fopost Core version:
 - Platform(s) affected:
 
 ## Additional Context

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <a href="https://owlstack.dev">
+  <a href="https://fopost.com">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/owlstacks/owlstack-docs/refs/heads/main/static/img/logo-light-transparent.png">
-      <img src="https://raw.githubusercontent.com/owlstacks/owlstack-docs/refs/heads/main/static/img/logo-dark-transparent.png" alt="Owlstack" height="200px">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/fopost/fopost-docs/refs/heads/main/static/img/logo-light-transparent.png">
+      <img src="https://raw.githubusercontent.com/fopost/fopost-docs/refs/heads/main/static/img/logo-dark-transparent.png" alt="Fopost" height="200px">
     </picture>
   </a>
 </p>
@@ -12,22 +12,22 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/owlstacks/owlstack-laravel/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/owlstacks/owlstack-laravel/tests.yml?branch=master&style=flat-square&label=tests" alt="Tests"></a>
-  <a href="https://packagist.org/packages/owlstack/owlstack-laravel"><img src="https://img.shields.io/packagist/v/owlstack/owlstack-laravel.svg?style=flat-square" alt="Latest Version"></a>
-  <a href="https://packagist.org/packages/owlstack/owlstack-laravel"><img src="https://img.shields.io/packagist/dt/owlstack/owlstack-laravel.svg?style=flat-square" alt="Total Downloads"></a>
-  <a href="https://packagist.org/packages/owlstack/owlstack-laravel"><img src="https://img.shields.io/packagist/php-v/owlstack/owlstack-laravel.svg?style=flat-square" alt="PHP Version"></a>
-  <a href="https://packagist.org/packages/owlstack/owlstack-laravel"><img src="https://img.shields.io/badge/laravel-10.x%20|%2011.x%20|%2012.x-FF2D20?style=flat-square&logo=laravel&logoColor=white" alt="Laravel Version"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/packagist/l/owlstack/owlstack-laravel.svg?style=flat-square" alt="License"></a>
-  <a href="https://github.com/owlstacks/owlstack-laravel"><img src="https://img.shields.io/github/stars/owlstacks/owlstack-laravel?style=flat-square" alt="GitHub Stars"></a>
+  <a href="https://github.com/fopost/social-laravel/actions/workflows/tests.yml"><img src="https://img.shields.io/github/actions/workflow/status/fopost/social-laravel/tests.yml?branch=master&style=flat-square&label=tests" alt="Tests"></a>
+  <a href="https://packagist.org/packages/fopost/social-laravel"><img src="https://img.shields.io/packagist/v/fopost/social-laravel.svg?style=flat-square" alt="Latest Version"></a>
+  <a href="https://packagist.org/packages/fopost/social-laravel"><img src="https://img.shields.io/packagist/dt/fopost/social-laravel.svg?style=flat-square" alt="Total Downloads"></a>
+  <a href="https://packagist.org/packages/fopost/social-laravel"><img src="https://img.shields.io/packagist/php-v/fopost/social-laravel.svg?style=flat-square" alt="PHP Version"></a>
+  <a href="https://packagist.org/packages/fopost/social-laravel"><img src="https://img.shields.io/badge/laravel-10.x%20|%2011.x%20|%2012.x-FF2D20?style=flat-square&logo=laravel&logoColor=white" alt="Laravel Version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/packagist/l/fopost/social-laravel.svg?style=flat-square" alt="License"></a>
+  <a href="https://github.com/fopost/social-laravel"><img src="https://img.shields.io/github/stars/fopost/social-laravel?style=flat-square" alt="GitHub Stars"></a>
 </p>
 
 ---
 
-# Owlstack for Laravel
+# Fopost for Laravel
 
-Laravel integration for [Owlstack Core](https://github.com/owlstacks/owlstack-core) — publish content to **11 social media platforms** (Telegram, X/Twitter, Facebook, LinkedIn, Instagram, Discord, Slack, Reddit, Pinterest, WhatsApp, and Tumblr) from your Laravel application.
+Laravel integration for [Fopost Core](https://github.com/fopost/social-core) — publish content to **11 social media platforms** (Telegram, X/Twitter, Facebook, LinkedIn, Instagram, Discord, Slack, Reddit, Pinterest, WhatsApp, and Tumblr) from your Laravel application.
 
-> **Note:** This package was previously `alihesari/larasap`. It has been rewritten from scratch to use `owlstack/owlstack-core` as its engine.
+> **Note:** This package was previously `alihesari/larasap`. It has been rewritten from scratch to use `fopost/social-core` as its engine.
 
 ## Requirements
 
@@ -37,13 +37,13 @@ Laravel integration for [Owlstack Core](https://github.com/owlstacks/owlstack-co
 ## Installation
 
 ```bash
-composer require owlstack/owlstack-laravel
+composer require fopost/social-laravel
 ```
 
 Publish the config file:
 
 ```bash
-php artisan vendor:publish --tag=owlstack-config
+php artisan vendor:publish --tag=fopost-config
 ```
 
 ## Configuration
@@ -108,9 +108,9 @@ TUMBLR_ACCESS_TOKEN=your-access-token
 TUMBLR_BLOG_IDENTIFIER=your-blog.tumblr.com
 
 # Proxy (optional — for restricted networks)
-OWLSTACK_PROXY_HOST=localhost
-OWLSTACK_PROXY_PORT=9050
-OWLSTACK_PROXY_TYPE=7
+FOPOST_PROXY_HOST=localhost
+FOPOST_PROXY_PORT=9050
+FOPOST_PROXY_TYPE=7
 ```
 
 Only platforms with valid credentials are registered. If you leave Twitter credentials empty, only Telegram and Facebook will be available.
@@ -120,7 +120,7 @@ Only platforms with valid credentials are registered. If you leave Twitter crede
 ### Via Dependency Injection (recommended)
 
 ```php
-use Owlstack\Laravel\SendTo;
+use Fopost\Social\Laravel\SendTo;
 
 class PostController extends Controller
 {
@@ -178,16 +178,16 @@ class PostController extends Controller
 ### Via Facade
 
 ```php
-use Owlstack\Laravel\Facades\Owlstack;
+use Fopost\Social\Laravel\Facades\FopostSocial;
 
-Owlstack::telegram('Hello from the facade!');
-Owlstack::twitter('Tweet from the facade!');
-Owlstack::linkedin('Post from the facade!');
+FopostSocial::telegram('Hello from the facade!');
+FopostSocial::twitter('Tweet from the facade!');
+FopostSocial::linkedin('Post from the facade!');
 ```
 
 ### Return Value
 
-All methods return a `Owlstack\Core\Publishing\PublishResult`:
+All methods return a `Fopost\Social\Publishing\PublishResult`:
 
 ```php
 $result = $sendTo->telegram('Hello!');
@@ -402,12 +402,12 @@ $sendTo->tumblr('Photo post', [
 
 ### Using Post Objects Directly
 
-For full control, create `Owlstack\Core\Content\Post` objects:
+For full control, create `Fopost\Social\Content\Post` objects:
 
 ```php
-use Owlstack\Core\Content\Post;
-use Owlstack\Core\Content\Media;
-use Owlstack\Core\Content\MediaCollection;
+use Fopost\Social\Content\Post;
+use Fopost\Social\Content\Media;
+use Fopost\Social\Content\MediaCollection;
 
 $post = new Post(
     title: 'My Article',
@@ -431,13 +431,13 @@ $results = $sendTo->toAll($post);
 
 The package dispatches events through Laravel's event system:
 
-- `Owlstack\Core\Events\PostPublished` — fired on successful publish
-- `Owlstack\Core\Events\PostFailed` — fired on publish failure
+- `Fopost\Social\Events\PostPublished` — fired on successful publish
+- `Fopost\Social\Events\PostFailed` — fired on publish failure
 
 ```php
 // In EventServiceProvider or via Event::listen()
-use Owlstack\Core\Events\PostPublished;
-use Owlstack\Core\Events\PostFailed;
+use Fopost\Social\Events\PostPublished;
+use Fopost\Social\Events\PostFailed;
 
 Event::listen(PostPublished::class, function (PostPublished $event) {
     Log::info("Published to {$event->result->platformName}", [
@@ -454,23 +454,23 @@ Event::listen(PostFailed::class, function (PostFailed $event) {
 
 ## Architecture
 
-This package is a thin wrapper around `owlstack/owlstack-core`. The architecture:
+This package is a thin wrapper around `fopost/social-core`. The architecture:
 
 ```
 Your Laravel App
-    └── Owlstack\Laravel\SendTo (or Facade)
-        └── Owlstack\Core\Publishing\Publisher
-            └── Owlstack\Core\Platforms\{Telegram,Twitter,Facebook,LinkedIn,...}Platform
-                └── Owlstack\Core\Http\HttpClient (cURL)
+    └── Fopost\Social\Laravel\SendTo (or Facade)
+        └── Fopost\Social\Publishing\Publisher
+            └── Fopost\Social\Platforms\{Telegram,Twitter,Facebook,LinkedIn,...}Platform
+                └── Fopost\Social\Http\HttpClient (cURL)
 ```
 
 The service provider wires everything together:
-- `OwlstackConfig` — built from `config/owlstack.php`
+- `FopostConfig` — built from `config/fopost-social.php`
 - `HttpClient` — core's cURL client (with optional proxy)
 - Platform instances — only registered if credentials are configured
 - `PlatformRegistry` — holds all active platforms
 - `Publisher` — orchestrates publishing with event dispatch
-- `SendTo` — high-level API bound as `'owlstack'` singleton
+- `SendTo` — high-level API bound as `'fopost-social'` singleton
 
 ## Testing
 
@@ -483,7 +483,7 @@ Or run PHPUnit directly:
 In your own tests, mock `HttpClientInterface` on the container:
 
 ```php
-use Owlstack\Core\Http\Contracts\HttpClientInterface;
+use Fopost\Social\Http\Contracts\HttpClientInterface;
 
 $mock = $this->createMock(HttpClientInterface::class);
 $mock->method('post')->willReturn([
@@ -499,10 +499,10 @@ $this->app->instance(HttpClientInterface::class, $mock);
 
 If upgrading from the old package:
 
-1. Replace `alihesari/larasap` with `owlstack/owlstack-laravel` in `composer.json`
-2. Rename `config/larasap.php` → `config/owlstack.php` (see new format above)
-3. Replace `Alihesari\Larasap\SendTo` with `Owlstack\Laravel\SendTo`
-4. Replace static calls (`SendTo::telegram(...)`) with DI or the new `Owlstack` facade
+1. Replace `alihesari/larasap` with `fopost/social-laravel` in `composer.json`
+2. Rename `config/larasap.php` → `config/fopost-social.php` (see new format above)
+3. Replace `Alihesari\Larasap\SendTo` with `Fopost\Social\Laravel\SendTo`
+4. Replace static calls (`SendTo::telegram(...)`) with DI or the new `Fopost` facade
 5. Update event listeners if you had custom ones
 6. The `facebook/graph-sdk` and `facebook/php-business-sdk` dependencies are no longer needed
 

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,11 @@
 {
-    "name": "owlstack/owlstack-laravel",
-    "description": "Laravel integration for Owlstack — publish content to Telegram, X (Twitter), Facebook, LinkedIn, Instagram, Discord, Slack, Reddit, Pinterest, WhatsApp, and Tumblr from your Laravel application.",
+    "name": "fopost/social-laravel",
+    "description": "Laravel integration for Fopost — publish content to Telegram, X (Twitter), Facebook, LinkedIn, Instagram, Discord, Slack, Reddit, Pinterest, WhatsApp, and Tumblr from your Laravel application.",
     "type": "library",
     "license": "MIT",
     "keywords": [
         "laravel",
-        "owlstack",
+        "fopost",
         "social-media",
         "telegram",
         "twitter",
@@ -30,14 +30,14 @@
             "role": "Developer"
         }
     ],
-    "homepage": "https://github.com/alihesari/owlstack-laravel",
+    "homepage": "https://github.com/alihesari/fopost-social-laravel",
     "support": {
-        "issues": "https://github.com/alihesari/owlstack-laravel/issues",
-        "source": "https://github.com/alihesari/owlstack-laravel"
+        "issues": "https://github.com/alihesari/fopost-social-laravel/issues",
+        "source": "https://github.com/alihesari/fopost-social-laravel"
     },
     "require": {
         "php": "^8.1",
-        "owlstack/owlstack-core": "^1.0",
+        "fopost/social-core": "^1.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0"
     },
@@ -47,21 +47,21 @@
     },
     "autoload": {
         "psr-4": {
-            "Owlstack\\Laravel\\": "src/"
+            "Fopost\\Social\\Laravel\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Owlstack\\Laravel\\Tests\\": "tests/"
+            "Fopost\\Social\\Laravel\\Tests\\": "tests/"
         }
     },
     "extra": {
         "laravel": {
             "providers": [
-                "Owlstack\\Laravel\\OwlstackServiceProvider"
+                "Fopost\\Social\\Laravel\\FopostSocialServiceProvider"
             ],
             "aliases": {
-                "Owlstack": "Owlstack\\Laravel\\Facades\\Owlstack"
+                "FopostSocial": "Fopost\\Social\\Laravel\\Facades\\FopostSocial"
             }
         }
     },

--- a/config/fopost-social.php
+++ b/config/fopost-social.php
@@ -8,6 +8,10 @@ return [
     |--------------------------------------------------------------------------
     | Platform Configurations
     |--------------------------------------------------------------------------
+    |
+    | Configure credentials and settings for each social media platform.
+    | Only platforms with credentials will be registered in the PlatformRegistry.
+    |
     */
 
     'platforms' => [
@@ -33,12 +37,6 @@ return [
             'page_access_token' => env('FACEBOOK_PAGE_ACCESS_TOKEN', ''),
             'page_id' => env('FACEBOOK_PAGE_ID', ''),
             'default_graph_version' => env('FACEBOOK_GRAPH_VERSION', 'v21.0'),
-        ],
-
-        'linkedin' => [
-            'access_token' => env('LINKEDIN_ACCESS_TOKEN', ''),
-            'person_id' => env('LINKEDIN_PERSON_ID', ''),
-            'organization_id' => env('LINKEDIN_ORGANIZATION_ID', ''),
         ],
 
         'reddit' => [
@@ -79,20 +77,30 @@ return [
             'blog_identifier' => env('TUMBLR_BLOG_IDENTIFIER', ''),
         ],
 
+        'linkedin' => [
+            'access_token' => env('LINKEDIN_ACCESS_TOKEN', ''),
+            'person_id' => env('LINKEDIN_PERSON_ID', ''),
+            'organization_id' => env('LINKEDIN_ORGANIZATION_ID', ''),
+        ],
+
     ],
 
     /*
     |--------------------------------------------------------------------------
     | Proxy Configuration
     |--------------------------------------------------------------------------
+    |
+    | Set proxy for servers that cannot access social networks directly
+    | (e.g., due to sanctions or network restrictions).
+    |
     */
 
     'proxy' => [
-        'type' => env('OWLSTACK_PROXY_TYPE', ''),
-        'hostname' => env('OWLSTACK_PROXY_HOST', ''),
-        'port' => env('OWLSTACK_PROXY_PORT', ''),
-        'username' => env('OWLSTACK_PROXY_USERNAME', ''),
-        'password' => env('OWLSTACK_PROXY_PASSWORD', ''),
+        'type' => env('FOPOST_PROXY_TYPE', ''),          // 7 for SOCKS5
+        'hostname' => env('FOPOST_PROXY_HOST', ''),       // e.g. localhost
+        'port' => env('FOPOST_PROXY_PORT', ''),           // e.g. 9050
+        'username' => env('FOPOST_PROXY_USERNAME', ''),
+        'password' => env('FOPOST_PROXY_PASSWORD', ''),
     ],
 
 ];

--- a/examples/laravel-12/app/Http/Controllers/SocialMediaController.php
+++ b/examples/laravel-12/app/Http/Controllers/SocialMediaController.php
@@ -3,9 +3,9 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Owlstack\Core\Content\Post;
-use Owlstack\Laravel\Facades\Owlstack;
-use Owlstack\Laravel\SendTo;
+use Fopost\Social\Content\Post;
+use Fopost\Social\Laravel\Facades\FopostSocial;
+use Fopost\Social\Laravel\SendTo;
 
 class SocialMediaController extends Controller
 {
@@ -80,7 +80,7 @@ class SocialMediaController extends Controller
             title: 'Cross-Platform Test',
             body: 'Test post from Laravel 12 to all platforms.',
             url: 'https://example.com',
-            tags: ['laravel', 'owlstack'],
+            tags: ['laravel', 'fopost'],
         );
 
         $results = $sendTo->toAll($post);
@@ -99,7 +99,7 @@ class SocialMediaController extends Controller
      */
     public function testFacade()
     {
-        $result = Owlstack::telegram('Hello from the Owlstack facade!');
+        $result = FopostSocial::telegram('Hello from the Fopost facade!');
 
         return response()->json([
             'success' => $result->success,

--- a/examples/laravel-12/composer.json
+++ b/examples/laravel-12/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "owlstack/owlstack-laravel": "*",
+        "fopost/social-laravel": "*",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1"
     },

--- a/examples/laravel-12/config/fopost-social.php
+++ b/examples/laravel-12/config/fopost-social.php
@@ -8,10 +8,6 @@ return [
     |--------------------------------------------------------------------------
     | Platform Configurations
     |--------------------------------------------------------------------------
-    |
-    | Configure credentials and settings for each social media platform.
-    | Only platforms with credentials will be registered in the PlatformRegistry.
-    |
     */
 
     'platforms' => [
@@ -37,6 +33,12 @@ return [
             'page_access_token' => env('FACEBOOK_PAGE_ACCESS_TOKEN', ''),
             'page_id' => env('FACEBOOK_PAGE_ID', ''),
             'default_graph_version' => env('FACEBOOK_GRAPH_VERSION', 'v21.0'),
+        ],
+
+        'linkedin' => [
+            'access_token' => env('LINKEDIN_ACCESS_TOKEN', ''),
+            'person_id' => env('LINKEDIN_PERSON_ID', ''),
+            'organization_id' => env('LINKEDIN_ORGANIZATION_ID', ''),
         ],
 
         'reddit' => [
@@ -77,30 +79,20 @@ return [
             'blog_identifier' => env('TUMBLR_BLOG_IDENTIFIER', ''),
         ],
 
-        'linkedin' => [
-            'access_token' => env('LINKEDIN_ACCESS_TOKEN', ''),
-            'person_id' => env('LINKEDIN_PERSON_ID', ''),
-            'organization_id' => env('LINKEDIN_ORGANIZATION_ID', ''),
-        ],
-
     ],
 
     /*
     |--------------------------------------------------------------------------
     | Proxy Configuration
     |--------------------------------------------------------------------------
-    |
-    | Set proxy for servers that cannot access social networks directly
-    | (e.g., due to sanctions or network restrictions).
-    |
     */
 
     'proxy' => [
-        'type' => env('OWLSTACK_PROXY_TYPE', ''),          // 7 for SOCKS5
-        'hostname' => env('OWLSTACK_PROXY_HOST', ''),       // e.g. localhost
-        'port' => env('OWLSTACK_PROXY_PORT', ''),           // e.g. 9050
-        'username' => env('OWLSTACK_PROXY_USERNAME', ''),
-        'password' => env('OWLSTACK_PROXY_PASSWORD', ''),
+        'type' => env('FOPOST_PROXY_TYPE', ''),
+        'hostname' => env('FOPOST_PROXY_HOST', ''),
+        'port' => env('FOPOST_PROXY_PORT', ''),
+        'username' => env('FOPOST_PROXY_USERNAME', ''),
+        'password' => env('FOPOST_PROXY_PASSWORD', ''),
     ],
 
 ];

--- a/src/Events/LaravelEventDispatcher.php
+++ b/src/Events/LaravelEventDispatcher.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel\Events;
+namespace Fopost\Social\Laravel\Events;
 
 use Illuminate\Contracts\Events\Dispatcher;
-use Owlstack\Core\Events\Contracts\EventDispatcherInterface;
+use Fopost\Social\Events\Contracts\EventDispatcherInterface;
 
 /**
- * Bridges Owlstack Core's EventDispatcherInterface to Laravel's event dispatcher.
+ * Bridges Fopost Core's EventDispatcherInterface to Laravel's event dispatcher.
  *
  * This allows core events (PostPublished, PostFailed) to be dispatched
  * through Laravel's event system, enabling standard Laravel listeners.

--- a/src/Facades/FopostSocial.php
+++ b/src/Facades/FopostSocial.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel\Facades;
+namespace Fopost\Social\Laravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
-use Owlstack\Core\Content\Post;
-use Owlstack\Core\Publishing\PublishResult;
+use Fopost\Social\Content\Post;
+use Fopost\Social\Publishing\PublishResult;
 
 /**
- * Owlstack Facade.
+ * Fopost Facade.
  *
  * @method static PublishResult telegram(string $message, ?array $attachment = null, array $inlineKeyboard = [], array $options = [])
  * @method static PublishResult twitter(string $message, ?array $media = null, array $options = [])
@@ -26,12 +26,12 @@ use Owlstack\Core\Publishing\PublishResult;
  * @method static PublishResult publish(Post $post, string $platform, array $options = [])
  * @method static array<string, PublishResult> toAll(Post $post, array $options = [])
  *
- * @see \Owlstack\Laravel\SendTo
+ * @see \Fopost\Social\Laravel\SendTo
  */
-class Owlstack extends Facade
+class FopostSocial extends Facade
 {
     protected static function getFacadeAccessor(): string
     {
-        return 'owlstack';
+        return 'fopost-social';
     }
 }

--- a/src/FopostSocialServiceProvider.php
+++ b/src/FopostSocialServiceProvider.php
@@ -2,27 +2,27 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel;
+namespace Fopost\Social\Laravel;
 
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
-use Owlstack\Core\Config\PlatformCredentials;
-use Owlstack\Core\Config\OwlstackConfig;
-use Owlstack\Core\Formatting\CharacterTruncator;
-use Owlstack\Core\Formatting\HashtagExtractor;
-use Owlstack\Core\Http\Contracts\HttpClientInterface;
-use Owlstack\Core\Http\HttpClient;
-use Owlstack\Core\Platforms\Facebook\FacebookFormatter;
-use Owlstack\Core\Platforms\Facebook\FacebookPlatform;
-use Owlstack\Core\Platforms\PlatformRegistry;
-use Owlstack\Core\Platforms\Telegram\TelegramFormatter;
-use Owlstack\Core\Platforms\Telegram\TelegramPlatform;
-use Owlstack\Core\Platforms\Twitter\TwitterFormatter;
-use Owlstack\Core\Platforms\Twitter\TwitterPlatform;
-use Owlstack\Core\Publishing\Publisher;
-use Owlstack\Laravel\Events\LaravelEventDispatcher;
+use Fopost\Social\Config\PlatformCredentials;
+use Fopost\Social\Config\FopostConfig;
+use Fopost\Social\Formatting\CharacterTruncator;
+use Fopost\Social\Formatting\HashtagExtractor;
+use Fopost\Social\Http\Contracts\HttpClientInterface;
+use Fopost\Social\Http\HttpClient;
+use Fopost\Social\Platforms\Facebook\FacebookFormatter;
+use Fopost\Social\Platforms\Facebook\FacebookPlatform;
+use Fopost\Social\Platforms\PlatformRegistry;
+use Fopost\Social\Platforms\Telegram\TelegramFormatter;
+use Fopost\Social\Platforms\Telegram\TelegramPlatform;
+use Fopost\Social\Platforms\Twitter\TwitterFormatter;
+use Fopost\Social\Platforms\Twitter\TwitterPlatform;
+use Fopost\Social\Publishing\Publisher;
+use Fopost\Social\Laravel\Events\LaravelEventDispatcher;
 
-class OwlstackServiceProvider extends ServiceProvider
+class FopostSocialServiceProvider extends ServiceProvider
 {
     /**
      * Register any application services.
@@ -30,8 +30,8 @@ class OwlstackServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->mergeConfigFrom(
-            __DIR__ . '/../config/owlstack.php',
-            'owlstack',
+            __DIR__ . '/../config/fopost-social.php',
+            'fopost-social',
         );
 
         $this->registerConfig();
@@ -49,8 +49,8 @@ class OwlstackServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__ . '/../config/owlstack.php' => config_path('owlstack.php'),
-            ], 'owlstack-config');
+                __DIR__ . '/../config/fopost-social.php' => config_path('fopost.php'),
+            ], 'fopost-config');
         }
     }
 
@@ -58,8 +58,8 @@ class OwlstackServiceProvider extends ServiceProvider
 
     private function registerConfig(): void
     {
-        $this->app->singleton(OwlstackConfig::class, function ($app) {
-            $platforms = $app['config']->get('owlstack.platforms', []);
+        $this->app->singleton(FopostConfig::class, function ($app) {
+            $platforms = $app['config']->get('fopost.platforms', []);
 
             // Filter out platforms with empty credentials
             $configured = [];
@@ -69,10 +69,10 @@ class OwlstackServiceProvider extends ServiceProvider
                 }
             }
 
-            return new OwlstackConfig(
+            return new FopostConfig(
                 platforms: $configured,
                 options: [
-                    'proxy' => $app['config']->get('owlstack.proxy', []),
+                    'proxy' => $app['config']->get('fopost.proxy', []),
                 ],
             );
         });
@@ -81,7 +81,7 @@ class OwlstackServiceProvider extends ServiceProvider
     private function registerHttpClient(): void
     {
         $this->app->singleton(HttpClientInterface::class, function ($app) {
-            $proxyConfig = $app['config']->get('owlstack.proxy', []);
+            $proxyConfig = $app['config']->get('fopost.proxy', []);
 
             $proxy = null;
             if (!empty($proxyConfig['hostname']) && !empty($proxyConfig['port'])) {
@@ -123,7 +123,7 @@ class OwlstackServiceProvider extends ServiceProvider
     {
         $this->app->singleton(PlatformRegistry::class, function ($app) {
             $registry = new PlatformRegistry();
-            $config = $app->make(OwlstackConfig::class);
+            $config = $app->make(FopostConfig::class);
 
             if ($config->hasPlatform('telegram')) {
                 $registry->register($app->make(TelegramPlatform::class));
@@ -135,28 +135,28 @@ class OwlstackServiceProvider extends ServiceProvider
                 $registry->register($app->make(FacebookPlatform::class));
             }
             if ($config->hasPlatform('reddit')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\Reddit\RedditPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\Reddit\RedditPlatform::class));
             }
             if ($config->hasPlatform('discord')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\Discord\DiscordPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\Discord\DiscordPlatform::class));
             }
             if ($config->hasPlatform('slack')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\Slack\SlackPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\Slack\SlackPlatform::class));
             }
             if ($config->hasPlatform('instagram')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\Instagram\InstagramPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\Instagram\InstagramPlatform::class));
             }
             if ($config->hasPlatform('pinterest')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\Pinterest\PinterestPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\Pinterest\PinterestPlatform::class));
             }
             if ($config->hasPlatform('whatsapp')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\WhatsApp\WhatsAppPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\WhatsApp\WhatsAppPlatform::class));
             }
             if ($config->hasPlatform('tumblr')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\Tumblr\TumblrPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\Tumblr\TumblrPlatform::class));
             }
             if ($config->hasPlatform('linkedin')) {
-                $registry->register($app->make(\Owlstack\Core\Platforms\LinkedIn\LinkedInPlatform::class));
+                $registry->register($app->make(\Fopost\Social\Platforms\LinkedIn\LinkedInPlatform::class));
             }
 
             return $registry;
@@ -164,7 +164,7 @@ class OwlstackServiceProvider extends ServiceProvider
 
         // Register individual platform classes
         $this->app->singleton(TelegramPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
+            $config = $app->make(FopostConfig::class);
             return new TelegramPlatform(
                 credentials: $config->credentials('telegram'),
                 httpClient: $app->make(HttpClientInterface::class),
@@ -172,7 +172,7 @@ class OwlstackServiceProvider extends ServiceProvider
             );
         });
         $this->app->singleton(TwitterPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
+            $config = $app->make(FopostConfig::class);
             return new TwitterPlatform(
                 credentials: $config->credentials('twitter'),
                 httpClient: $app->make(HttpClientInterface::class),
@@ -180,7 +180,7 @@ class OwlstackServiceProvider extends ServiceProvider
             );
         });
         $this->app->singleton(FacebookPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
+            $config = $app->make(FopostConfig::class);
             $graphVersion = $config->credentials('facebook')?->get('default_graph_version', 'v21.0') ?? 'v21.0';
             return new FacebookPlatform(
                 credentials: $config->credentials('facebook'),
@@ -189,68 +189,68 @@ class OwlstackServiceProvider extends ServiceProvider
                 graphVersion: $graphVersion,
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\Reddit\RedditPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\Reddit\RedditPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\Reddit\RedditPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\Reddit\RedditPlatform(
                 credentials: $config->credentials('reddit'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\Reddit\RedditFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\Reddit\RedditFormatter::class),
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\Discord\DiscordPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\Discord\DiscordPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\Discord\DiscordPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\Discord\DiscordPlatform(
                 credentials: $config->credentials('discord'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\Discord\DiscordFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\Discord\DiscordFormatter::class),
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\Slack\SlackPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\Slack\SlackPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\Slack\SlackPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\Slack\SlackPlatform(
                 credentials: $config->credentials('slack'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\Slack\SlackFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\Slack\SlackFormatter::class),
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\Instagram\InstagramPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\Instagram\InstagramPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\Instagram\InstagramPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\Instagram\InstagramPlatform(
                 credentials: $config->credentials('instagram'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\Instagram\InstagramFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\Instagram\InstagramFormatter::class),
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\Pinterest\PinterestPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\Pinterest\PinterestPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\Pinterest\PinterestPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\Pinterest\PinterestPlatform(
                 credentials: $config->credentials('pinterest'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\Pinterest\PinterestFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\Pinterest\PinterestFormatter::class),
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\WhatsApp\WhatsAppPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\WhatsApp\WhatsAppPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\WhatsApp\WhatsAppPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\WhatsApp\WhatsAppPlatform(
                 credentials: $config->credentials('whatsapp'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\WhatsApp\WhatsAppFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\WhatsApp\WhatsAppFormatter::class),
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\Tumblr\TumblrPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\Tumblr\TumblrPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\Tumblr\TumblrPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\Tumblr\TumblrPlatform(
                 credentials: $config->credentials('tumblr'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\Tumblr\TumblrFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\Tumblr\TumblrFormatter::class),
             );
         });
-        $this->app->singleton(\Owlstack\Core\Platforms\LinkedIn\LinkedInPlatform::class, function ($app) {
-            $config = $app->make(OwlstackConfig::class);
-            return new \Owlstack\Core\Platforms\LinkedIn\LinkedInPlatform(
+        $this->app->singleton(\Fopost\Social\Platforms\LinkedIn\LinkedInPlatform::class, function ($app) {
+            $config = $app->make(FopostConfig::class);
+            return new \Fopost\Social\Platforms\LinkedIn\LinkedInPlatform(
                 credentials: $config->credentials('linkedin'),
                 httpClient: $app->make(HttpClientInterface::class),
-                formatter: $app->make(\Owlstack\Core\Platforms\LinkedIn\LinkedInFormatter::class),
+                formatter: $app->make(\Fopost\Social\Platforms\LinkedIn\LinkedInFormatter::class),
             );
         });
     }
@@ -271,15 +271,15 @@ class OwlstackServiceProvider extends ServiceProvider
 
     private function registerSendTo(): void
     {
-        $this->app->singleton('owlstack', function ($app) {
+        $this->app->singleton('fopost-social', function ($app) {
             return new SendTo(
                 publisher: $app->make(Publisher::class),
-                config: $app->make(OwlstackConfig::class),
+                config: $app->make(FopostConfig::class),
                 registry: $app->make(PlatformRegistry::class),
             );
         });
 
-        $this->app->alias('owlstack', SendTo::class);
+        $this->app->alias('fopost-social', SendTo::class);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/SendTo.php
+++ b/src/SendTo.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel;
+namespace Fopost\Social\Laravel;
 
-use Owlstack\Core\Config\OwlstackConfig;
-use Owlstack\Core\Content\Media;
-use Owlstack\Core\Content\MediaCollection;
-use Owlstack\Core\Content\Post;
-use Owlstack\Core\Platforms\PlatformRegistry;
-use Owlstack\Core\Platforms\Telegram\TelegramPlatform;
-use Owlstack\Core\Publishing\Publisher;
-use Owlstack\Core\Publishing\PublishResult;
+use Fopost\Social\Config\FopostConfig;
+use Fopost\Social\Content\Media;
+use Fopost\Social\Content\MediaCollection;
+use Fopost\Social\Content\Post;
+use Fopost\Social\Platforms\PlatformRegistry;
+use Fopost\Social\Platforms\Telegram\TelegramPlatform;
+use Fopost\Social\Publishing\Publisher;
+use Fopost\Social\Publishing\PublishResult;
 
 /**
  * High-level Laravel API for publishing content to social media platforms.
@@ -22,7 +22,7 @@ use Owlstack\Core\Publishing\PublishResult;
  *     }
  *
  * Usage via Facade:
- *     Owlstack::telegram('Hello world!');
+ *     FopostSocial::telegram('Hello world!');
  */
 class SendTo
 {
@@ -31,7 +31,7 @@ class SendTo
 
     public function __construct(
         private readonly Publisher $publisher,
-        private readonly OwlstackConfig $config,
+        private readonly FopostConfig $config,
         private readonly PlatformRegistry $registry,
     ) {
     }

--- a/tests/Feature/PublishingTest.php
+++ b/tests/Feature/PublishingTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel\Tests\Feature;
+namespace Fopost\Social\Laravel\Tests\Feature;
 
 use Illuminate\Support\Facades\Event;
-use Owlstack\Core\Events\PostPublished;
-use Owlstack\Core\Events\PostFailed;
-use Owlstack\Core\Content\Post;
-use Owlstack\Laravel\Facades\Owlstack;
-use Owlstack\Laravel\SendTo;
-use Owlstack\Laravel\Tests\TestCase;
+use Fopost\Social\Events\PostPublished;
+use Fopost\Social\Events\PostFailed;
+use Fopost\Social\Content\Post;
+use Fopost\Social\Laravel\Facades\FopostSocial;
+use Fopost\Social\Laravel\SendTo;
+use Fopost\Social\Laravel\Tests\TestCase;
 
 class PublishingTest extends TestCase
 {
@@ -21,7 +21,7 @@ class PublishingTest extends TestCase
             ->method('post')
             ->willReturn($this->telegramSuccess());
 
-        $result = Owlstack::telegram('Via facade');
+        $result = FopostSocial::telegram('Via facade');
 
         $this->assertTrue($result->success);
     }
@@ -90,7 +90,7 @@ class PublishingTest extends TestCase
         $post = new Post(
             title: 'Full Workflow Title',
             body: 'Full workflow body text for testing.',
-            tags: ['owlstack', 'test'],
+            tags: ['fopost', 'test'],
         );
 
         /** @var SendTo $sendTo */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel\Tests;
+namespace Fopost\Social\Laravel\Tests;
 
 use Orchestra\Testbench\TestCase as BaseTestCase;
-use Owlstack\Core\Http\Contracts\HttpClientInterface;
-use Owlstack\Laravel\OwlstackServiceProvider;
+use Fopost\Social\Http\Contracts\HttpClientInterface;
+use Fopost\Social\Laravel\FopostSocialServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -24,14 +24,14 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app): array
     {
         return [
-            OwlstackServiceProvider::class,
+            FopostSocialServiceProvider::class,
         ];
     }
 
     protected function getEnvironmentSetUp($app): void
     {
         // Configure all platforms with test credentials
-        $app['config']->set('owlstack.platforms.telegram', [
+        $app['config']->set('fopost.platforms.telegram', [
             'api_token' => 'test-token-123',
             'bot_username' => 'test_bot',
             'channel_username' => '@test_channel',
@@ -39,14 +39,14 @@ abstract class TestCase extends BaseTestCase
             'parse_mode' => 'HTML',
         ]);
 
-        $app['config']->set('owlstack.platforms.twitter', [
+        $app['config']->set('fopost.platforms.twitter', [
             'consumer_key' => 'test_consumer_key',
             'consumer_secret' => 'test_consumer_secret',
             'access_token' => 'test_access_token',
             'access_token_secret' => 'test_access_token_secret',
         ]);
 
-        $app['config']->set('owlstack.platforms.facebook', [
+        $app['config']->set('fopost.platforms.facebook', [
             'app_id' => 'test_app_id',
             'app_secret' => 'test_app_secret',
             'page_access_token' => 'test_page_token',
@@ -54,7 +54,7 @@ abstract class TestCase extends BaseTestCase
             'default_graph_version' => 'v21.0',
         ]);
 
-        $app['config']->set('owlstack.platforms.linkedin', [
+        $app['config']->set('fopost.platforms.linkedin', [
             'access_token' => 'test_linkedin_token',
             'person_id' => 'test_person_id',
             'organization_id' => '',

--- a/tests/Unit/SendToTest.php
+++ b/tests/Unit/SendToTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel\Tests\Unit;
+namespace Fopost\Social\Laravel\Tests\Unit;
 
-use Owlstack\Laravel\SendTo;
-use Owlstack\Laravel\Tests\TestCase;
+use Fopost\Social\Laravel\SendTo;
+use Fopost\Social\Laravel\Tests\TestCase;
 
 class SendToTest extends TestCase
 {
@@ -108,19 +108,19 @@ class SendToTest extends TestCase
     public function testTelegramWithSignature(): void
     {
         // Enable signature in config
-        $this->app['config']->set('owlstack.platforms.telegram.channel_signature', '— Test Bot');
+        $this->app['config']->set('fopost.platforms.telegram.channel_signature', '— Test Bot');
 
         // Re-register to pick up new config
-        $this->app->forgetInstance(\Owlstack\Core\Config\OwlstackConfig::class);
-        $this->app->forgetInstance(\Owlstack\Core\Platforms\PlatformRegistry::class);
-        $this->app->forgetInstance(\Owlstack\Core\Platforms\Telegram\TelegramPlatform::class);
-        $this->app->forgetInstance(\Owlstack\Core\Publishing\Publisher::class);
+        $this->app->forgetInstance(\Fopost\Social\Config\FopostConfig::class);
+        $this->app->forgetInstance(\Fopost\Social\Platforms\PlatformRegistry::class);
+        $this->app->forgetInstance(\Fopost\Social\Platforms\Telegram\TelegramPlatform::class);
+        $this->app->forgetInstance(\Fopost\Social\Publishing\Publisher::class);
         $this->app->forgetInstance(SendTo::class);
-        $this->app->forgetInstance('owlstack');
-        (new \Owlstack\Laravel\OwlstackServiceProvider($this->app))->register();
+        $this->app->forgetInstance('fopost-social');
+        (new \Fopost\Social\Laravel\FopostSocialServiceProvider($this->app))->register();
 
         // Re-bind the mock HTTP client after re-registration
-        $this->app->instance(\Owlstack\Core\Http\Contracts\HttpClientInterface::class, $this->httpClient);
+        $this->app->instance(\Fopost\Social\Http\Contracts\HttpClientInterface::class, $this->httpClient);
 
         $this->httpClient
             ->expects($this->once())
@@ -323,7 +323,7 @@ class SendToTest extends TestCase
             ->method('post')
             ->willReturn($this->telegramSuccess());
 
-        $post = new \Owlstack\Core\Content\Post(
+        $post = new \Fopost\Social\Content\Post(
             title: 'Direct Post',
             body: 'Published via Post object',
         );
@@ -348,7 +348,7 @@ class SendToTest extends TestCase
                 $this->linkedinSuccess(),
             );
 
-        $post = new \Owlstack\Core\Content\Post(
+        $post = new \Fopost\Social\Content\Post(
             title: 'Cross-platform',
             body: 'Post to all platforms',
         );

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -2,39 +2,39 @@
 
 declare(strict_types=1);
 
-namespace Owlstack\Laravel\Tests\Unit;
+namespace Fopost\Social\Laravel\Tests\Unit;
 
-use Owlstack\Core\Config\OwlstackConfig;
-use Owlstack\Core\Http\Contracts\HttpClientInterface;
-use Owlstack\Core\Platforms\PlatformRegistry;
-use Owlstack\Core\Platforms\Telegram\TelegramPlatform;
-use Owlstack\Core\Platforms\Twitter\TwitterPlatform;
-use Owlstack\Core\Platforms\Facebook\FacebookPlatform;
-use Owlstack\Core\Publishing\Publisher;
-use Owlstack\Laravel\Events\LaravelEventDispatcher;
-use Owlstack\Laravel\SendTo;
-use Owlstack\Laravel\OwlstackServiceProvider;
-use Owlstack\Laravel\Tests\TestCase;
+use Fopost\Social\Config\FopostConfig;
+use Fopost\Social\Http\Contracts\HttpClientInterface;
+use Fopost\Social\Platforms\PlatformRegistry;
+use Fopost\Social\Platforms\Telegram\TelegramPlatform;
+use Fopost\Social\Platforms\Twitter\TwitterPlatform;
+use Fopost\Social\Platforms\Facebook\FacebookPlatform;
+use Fopost\Social\Publishing\Publisher;
+use Fopost\Social\Laravel\Events\LaravelEventDispatcher;
+use Fopost\Social\Laravel\SendTo;
+use Fopost\Social\Laravel\FopostSocialServiceProvider;
+use Fopost\Social\Laravel\Tests\TestCase;
 
 class ServiceProviderTest extends TestCase
 {
     public function testServiceProviderIsRegistered(): void
     {
         $this->assertInstanceOf(
-            OwlstackServiceProvider::class,
-            $this->app->getProvider(OwlstackServiceProvider::class),
+            FopostSocialServiceProvider::class,
+            $this->app->getProvider(FopostSocialServiceProvider::class),
         );
     }
 
-    public function testOwlstackConfigIsBound(): void
+    public function testFopostConfigIsBound(): void
     {
-        $config = $this->app->make(OwlstackConfig::class);
-        $this->assertInstanceOf(OwlstackConfig::class, $config);
+        $config = $this->app->make(FopostConfig::class);
+        $this->assertInstanceOf(FopostConfig::class, $config);
     }
 
     public function testConfigHasAllPlatforms(): void
     {
-        $config = $this->app->make(OwlstackConfig::class);
+        $config = $this->app->make(FopostConfig::class);
 
         $this->assertTrue($config->hasPlatform('telegram'));
         $this->assertTrue($config->hasPlatform('twitter'));
@@ -44,7 +44,7 @@ class ServiceProviderTest extends TestCase
     public function testConfigFiltersPlatformsWithEmptyCredentials(): void
     {
         // Override twitter config with empty credentials
-        $this->app['config']->set('owlstack.platforms.twitter', [
+        $this->app['config']->set('fopost.platforms.twitter', [
             'consumer_key' => '',
             'consumer_secret' => '',
             'access_token' => '',
@@ -52,10 +52,10 @@ class ServiceProviderTest extends TestCase
         ]);
 
         // Re-register so the singleton is rebuilt
-        $this->app->forgetInstance(OwlstackConfig::class);
-        (new OwlstackServiceProvider($this->app))->register();
+        $this->app->forgetInstance(FopostConfig::class);
+        (new FopostSocialServiceProvider($this->app))->register();
 
-        $config = $this->app->make(OwlstackConfig::class);
+        $config = $this->app->make(FopostConfig::class);
         $this->assertFalse($config->hasPlatform('twitter'));
         $this->assertTrue($config->hasPlatform('telegram'));
     }
@@ -119,7 +119,7 @@ class ServiceProviderTest extends TestCase
 
     public function testSendToIsBound(): void
     {
-        $sendTo = $this->app->make('owlstack');
+        $sendTo = $this->app->make('fopost-social');
         $this->assertInstanceOf(SendTo::class, $sendTo);
     }
 
@@ -131,12 +131,12 @@ class ServiceProviderTest extends TestCase
 
     public function testConfigPublishing(): void
     {
-        $this->artisan('vendor:publish', ['--tag' => 'owlstack-config', '--force' => true]);
+        $this->artisan('vendor:publish', ['--tag' => 'fopost-config', '--force' => true]);
 
         // The config file should have been published
-        $this->assertFileExists(config_path('owlstack.php'));
+        $this->assertFileExists(config_path('fopost.php'));
 
         // Clean up
-        @unlink(config_path('owlstack.php'));
+        @unlink(config_path('fopost.php'));
     }
 }


### PR DESCRIPTION
Package becomes fopost/social-laravel with the Fopost\Social\Laravel namespace, matching fopost/social-core. The service provider, facade and config are suffixed Social so the package can coexist with fopost/laravel, which already owns Fopost\Laravel and config/fopost.php.