### PR TITLE
ci(tests): stop Composer blocking EOL Laravel releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Install dependencies
         run: |
+          # EOL Laravel releases carry unpatched advisories; Composer blocks them by default
+          composer config policy.advisories.block false || composer config audit.block-insecure false
           composer require "illuminate/support:${{ matrix.laravel }}" "illuminate/contracts:${{ matrix.laravel }}" --no-interaction --no-update
           composer install --prefer-dist --no-interaction --no-progress
 


### PR DESCRIPTION
Composer 2.9+ refuses to install package versions with known security advisories. Laravel 10 and 11 are past end-of-life, so every release carries unpatched advisories and the matrix jobs for them could not even resolve dependencies. Disable the block for CI installs; the fallback covers the pre-2.10 config key name.